### PR TITLE
Add option to read .env before starting server

### DIFF
--- a/packages/next/cli/next-dev.ts
+++ b/packages/next/cli/next-dev.ts
@@ -79,6 +79,7 @@ const nextDev: cliCommand = async (argv) => {
     '--port': Number,
     '--hostname': String,
     '--turbo': Boolean,
+    '--readDotEnv': Boolean,
 
     // To align current messages with native binary.
     // Will need to adjust subcommand later.
@@ -114,6 +115,7 @@ const nextDev: cliCommand = async (argv) => {
       Options
         --port, -p      A port number on which to start the application
         --hostname, -H  Hostname on which to start the application (default: 0.0.0.0)
+        --readDotEnv    Read .env file before starting the application
         --help, -h      Displays this message
     `)
     process.exit(0)
@@ -143,7 +145,7 @@ const nextDev: cliCommand = async (argv) => {
     }
   }
 
-  const port = getPort(args)
+  const port = getPort(args, Log)
   // If neither --port nor PORT were specified, it's okay to retry new ports.
   const allowRetry =
     args['--port'] === undefined && process.env.PORT === undefined

--- a/packages/next/cli/next-start.ts
+++ b/packages/next/cli/next-start.ts
@@ -15,6 +15,7 @@ const nextStart: cliCommand = (argv) => {
     '--port': Number,
     '--hostname': String,
     '--keepAliveTimeout': Number,
+    '--readDotEnv': Boolean,
 
     // Aliases
     '-h': '--help',
@@ -43,17 +44,18 @@ const nextStart: cliCommand = (argv) => {
       If no directory is provided, the current directory will be used.
 
       Options
-        --port, -p      A port number on which to start the application
-        --hostname, -H  Hostname on which to start the application (default: 0.0.0.0)
+        --port, -p          A port number on which to start the application
+        --hostname, -H      Hostname on which to start the application (default: 0.0.0.0)
         --keepAliveTimeout  Max milliseconds to wait before closing inactive connections
-        --help, -h      Displays this message
+        --readDotEnv        Read .env file before starting the application
+        --help, -h          Displays this message
     `)
     process.exit(0)
   }
 
   const dir = getProjectDir(args._[0])
   const host = args['--hostname'] || '0.0.0.0'
-  const port = getPort(args)
+  const port = getPort(args, Log)
 
   const keepAliveTimeoutArg: number | undefined = args['--keepAliveTimeout']
   if (

--- a/packages/next/server/lib/utils.ts
+++ b/packages/next/server/lib/utils.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path'
 import type arg from 'next/dist/compiled/arg/index.js'
 
 export function printAndExit(message: string, code = 1) {
@@ -15,9 +16,29 @@ export function getNodeOptionsWithoutInspect() {
   return (process.env.NODE_OPTIONS || '').replace(NODE_INSPECT_RE, '')
 }
 
-export function getPort(args: arg.Result<arg.Spec>): number {
+type Log = {
+  info: (...args: any[]) => void
+  error: (...args: any[]) => void
+}
+
+export function getPort(args: arg.Result<arg.Spec>, log?: Log): number {
   if (typeof args['--port'] === 'number') {
     return args['--port']
+  }
+
+  if (args['--readDotEnv']) {
+    const findUp =
+      require('next/dist/compiled/find-up') as typeof import('next/dist/compiled/find-up')
+    const { getDotEnvFilenames, loadEnvConfig } =
+      require('@next/env') as typeof import('@next/env')
+    const isDev = process.env.NODE_ENV === 'development'
+    const isTest = process.env.NODE_ENV === 'test'
+    const mode = isTest ? 'test' : isDev ? 'development' : 'production'
+    const dotenvFiles = getDotEnvFilenames(mode)
+    const envPath = findUp.sync(dotenvFiles)
+    if (envPath) {
+      loadEnvConfig(dirname(envPath), isDev, log)
+    }
   }
 
   const parsed = process.env.PORT && parseInt(process.env.PORT, 10)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->

## Bug

- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] [e2e](https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs) tests added
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)

## Documentation / Examples

- [ ] Make sure the linting passes by running `pnpm build && pnpm lint`
- [ ] The "examples guidelines" are followed from [our contributing doc](https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md)
